### PR TITLE
Do not require driver gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
+gem "mongo", require: false
+gem "pg", require: false
+gem "redis", require: false
+gem "sqlite", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
     ruby-progressbar (1.11.0)
+    sqlite (1.0.2)
     sqlite3 (1.4.4)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
@@ -62,12 +63,13 @@ DEPENDENCIES
   bundler (~> 2.1)
   byebug
   dotenv
-  mongo (>= 2.14.0)
-  pg (>= 1.2)
+  mongo
+  pg
   rake (~> 12.0)
-  redis (>= 4.2)
+  redis
   rspec (~> 3.0)
   rubocop (= 1.0.0)
+  sqlite
   sqlite3 (>= 1.4.4)
   trifle-stats!
 

--- a/lib/trifle/stats/driver/mongo.rb
+++ b/lib/trifle/stats/driver/mongo.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'mongo'
 require_relative '../mixins/packer'
 
 module Trifle

--- a/lib/trifle/stats/driver/postgres.rb
+++ b/lib/trifle/stats/driver/postgres.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'pg'
 require_relative '../mixins/packer'
 
 module Trifle

--- a/lib/trifle/stats/driver/redis.rb
+++ b/lib/trifle/stats/driver/redis.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'redis'
 require_relative '../mixins/packer'
 
 module Trifle

--- a/lib/trifle/stats/driver/sqlite.rb
+++ b/lib/trifle/stats/driver/sqlite.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'sqlite3'
 require_relative '../mixins/packer'
 
 module Trifle


### PR DESCRIPTION
Requiring driver gems resulted in `Trifle::Stats` failing to load if user didnt had all database gems in his Gemfile.

This PR makes them optional and user needs to have database gem in his Gemfile if he wants to use the specific driver.